### PR TITLE
docs: document GitHub sub-issues API and CLI issue template patterns

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,7 +48,7 @@ gh api repos/masriamir/umbra/issues/{parent_number}/sub_issues \
 
 Repeat for each child. Closing keywords in PR bodies (above) handle auto-close on merge; the sub-issues API wires up the GitHub hierarchy independently of that.
 
-**Creating issues via CLI:** The YAML form templates in `.github/ISSUE_TEMPLATE/` only render in the GitHub web UI. When using `gh issue create`, mirror the template structure manually in the `--body` text. Available templates: `bug-report.yml` (fields: Description, Steps to reproduce, Expected behavior, Actual behavior, Area, Environment) and `feature-request.yml` (fields: Problem statement, Proposed solution, Alternatives considered, Area, Additional context).
+**Creating issues via CLI:** The YAML form templates in `.github/ISSUE_TEMPLATE/` only render in the GitHub web UI. When using `gh issue create`, mirror the template structure manually in the `--body` text. Available templates: `bug-report.yml` (fields: Description, Steps to reproduce, Expected behavior, Actual behavior, Area, Environment, Additional context) and `feature-request.yml` (fields: Problem statement, Proposed solution, Alternatives considered, Area, Additional context).
 
 **Security:** Run `/security-audit` (or `/security-audit backend|frontend|deps`) to trigger a full AI-powered security review. A `PreToolUse` hook on `git commit` automatically blocks commits that stage `.env` files or obvious hardcoded credentials — see `.claude/hooks/pre-commit-check.sh`.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,7 +29,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Prefer `git pull --rebase` over `git pull` when syncing a branch with its remote tracking branch.
 
-**GitHub issue linking:** When creating a PR or writing a commit message that completes a GitHub issue, include a closing keyword so GitHub auto-closes the issue on merge. Use `Closes #NNN`, `Fixes #NNN`, or `Resolves #NNN` (GitHub recognises all three and their past tense variants). Put the keyword in the PR body (preferred) or in the final commit message. Never use informal phrasing like "related to #NNN" when the intent is to close the issue.
+**GitHub issue linking:** When creating a PR or writing a commit message that completes a GitHub issue, include a closing keyword so GitHub auto-closes the issue on merge. Use `Closes #NNN`, `Fixes #NNN`, or `Resolves #NNN` (GitHub recognises all three and their past tense variants). Put the keyword in the PR body (preferred) or in the final commit message. Never use informal phrasing like "related to #NNN" when the intent is to close the issue. A single PR can close multiple issues — add one closing keyword per issue it fully resolves:
+
+```
+Closes #27   # implementation sub-issue
+Closes #25   # parent tracking issue
+```
+
+Only add a closing keyword for an issue the PR genuinely completes. Do not close a parent or umbrella issue early — wait until the PR delivers its full scope.
+
+**GitHub sub-issues:** Use the sub-issues API to formally attach child issues to a parent (creates the hierarchical progress tracker visible in the GitHub UI):
+
+```bash
+gh api repos/masriamir/umbra/issues/{parent_number}/sub_issues \
+  --method POST \
+  --field sub_issue_id=$(gh api repos/masriamir/umbra/issues/{child_number} --jq '.id')
+```
+
+Repeat for each child. Closing keywords in PR bodies (above) handle auto-close on merge; the sub-issues API wires up the GitHub hierarchy independently of that.
+
+**Creating issues via CLI:** The YAML form templates in `.github/ISSUE_TEMPLATE/` only render in the GitHub web UI. When using `gh issue create`, mirror the template structure manually in the `--body` text. Available templates: `bug-report.yml` (fields: Description, Steps to reproduce, Expected behavior, Actual behavior, Area, Environment) and `feature-request.yml` (fields: Problem statement, Proposed solution, Alternatives considered, Area, Additional context).
 
 **Security:** Run `/security-audit` (or `/security-audit backend|frontend|deps`) to trigger a full AI-powered security review. A `PreToolUse` hook on `git commit` automatically blocks commits that stage `.env` files or obvious hardcoded credentials — see `.claude/hooks/pre-commit-check.sh`.
 


### PR DESCRIPTION
## Summary

- Extends the **GitHub issue linking** section to make clear that a single PR can close multiple issues with one `Closes` keyword per issue — not just the direct sub-issue, but also any parent or umbrella issue the PR fully completes. Adds an explicit rule against closing a parent prematurely.
- Adds a new **GitHub sub-issues** section documenting the `gh api` command for formally attaching child issues to a parent via the GitHub sub-issues API, and clarifies that this hierarchy wiring is independent of PR auto-close keywords.
- Adds a new **Creating issues via CLI** section noting that YAML form templates only render in the web UI, and listing the fields for both existing templates (`bug-report.yml` and `feature-request.yml`) so issues created with `gh issue create` can mirror the correct structure.

## Additional context

These patterns were established during the Railpack migration work (issues #25–28) and weren't previously documented anywhere in `.claude/`.

## Test plan

- [ ] Read through the updated `CLAUDE.md` and confirm the three new sections are clear and unambiguous
- [ ] Verify no existing guidance was accidentally altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)