### PR TITLE
Migrate ruff configuration from pyproject.toml to ruff.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,89 +64,6 @@ quality = [
     "pre-commit>=4.6.0,<5.0.0",  # Pre-commit hooks
 ]
 
-[tool.ruff]
-extend-exclude = [
-    "todo/migrations",
-]
-line-length = 88
-target-version = "py314"
-src = [
-    "todo",
-    "umbra",
-]
-
-[tool.ruff.lint]
-select = [
-    #"ANN",  # flake8-annotations
-    "S",  # flake8-bandit
-    "B",  # flake8-bugbear
-    "A",  # flake8-builtins
-    "COM",  # flake8-commas
-    "C4",  # flake8-comprehensions
-    #"DTZ",  # flake8-datetimez
-    #"INT",  # flake8-gettext
-    #"ISC",  # flake8-implicit-str-concat
-    #"ICN",  # flake8-import-conventions
-    #"LOG",  # flake8-logging
-    #"G",  # flake8-logging-format
-    "T20",  # flake8-print
-    #"PYI",  # flake8-pyi
-    #"PT",  # flake8-pytest-style
-    #"Q",  # flake8-quotes
-    #"RET",  # flake8-return
-    #"SLF",  # flake8-self
-    #"SIM",  # flake8-simplify
-    #"TC",  # flake8-type-checking
-    #"ARG",  # flake8-unused-arguments
-    "PTH",  # flake8-use-pathlib
-    "I",  # isort
-    "C90",  # mccabe
-    "N",  # pep8-naming
-    "E",  # pycodestyle-error
-    "W",  # pycodestyle-warning
-    #"DOC",  # pydoclint
-    "D",  # pydocstyle
-    "F",  # Pyflakes
-    "PL",  # Pylint
-    "UP",  # pyupgrade
-    "RUF"  # Ruff-specific rules
-]
-ignore = [
-    "E501",  # Line too long
-    "COM812",  # Missing trailing comma
-    "RUF012",  # Mutable default value for class attribute
-    "D105",  # Missing docstring in magic method (__str__ etc. are self-evident)
-    "D106",  # Missing docstring in public nested class (Django/DRF Meta classes)
-    "D107",  # Missing docstring in __init__ (covered by class docstring)
-]
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
-line-ending = "auto"
-docstring-code-format = true
-docstring-code-line-length = "dynamic"
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**" = [
-    "S101",  # assert statements
-    "S106",  # hardcoded passwords
-    "PLR2004",  # Magic value comparisons in tests
-    "PLC0415",  # Import is not at top level
-    "D102",  # Test methods don't need docstrings
-    "D103",  # Test functions and fixtures don't need docstrings
-]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
-
-[tool.ruff.lint.isort]
-known-first-party = [
-    "todo",
-    "umbra",
-]
-
 [tool.uv]
 cache-keys = [
     { file = "pyproject.toml" },
@@ -165,5 +82,3 @@ python-version = "3.14"
 source = "vcs"
 fallback-version = "0.1.0"
 
-[tool.ruff.lint.flake8-quotes]
-inline-quotes = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,84 @@
+extend-exclude = [
+    "todo/migrations",
+]
+line-length = 88
+target-version = "py314"
+src = [
+    "todo",
+    "umbra",
+]
+
+[lint]
+select = [
+    #"ANN",  # flake8-annotations
+    "S",  # flake8-bandit
+    "B",  # flake8-bugbear
+    "A",  # flake8-builtins
+    "COM",  # flake8-commas
+    "C4",  # flake8-comprehensions
+    #"DTZ",  # flake8-datetimez
+    #"INT",  # flake8-gettext
+    #"ISC",  # flake8-implicit-str-concat
+    #"ICN",  # flake8-import-conventions
+    #"LOG",  # flake8-logging
+    #"G",  # flake8-logging-format
+    "T20",  # flake8-print
+    #"PYI",  # flake8-pyi
+    #"PT",  # flake8-pytest-style
+    #"Q",  # flake8-quotes
+    #"RET",  # flake8-return
+    #"SLF",  # flake8-self
+    #"SIM",  # flake8-simplify
+    #"TC",  # flake8-type-checking
+    #"ARG",  # flake8-unused-arguments
+    "PTH",  # flake8-use-pathlib
+    "I",  # isort
+    "C90",  # mccabe
+    "N",  # pep8-naming
+    "E",  # pycodestyle-error
+    "W",  # pycodestyle-warning
+    #"DOC",  # pydoclint
+    "D",  # pydocstyle
+    "F",  # Pyflakes
+    "PL",  # Pylint
+    "UP",  # pyupgrade
+    "RUF"  # Ruff-specific rules
+]
+ignore = [
+    "E501",  # Line too long
+    "COM812",  # Missing trailing comma
+    "RUF012",  # Mutable default value for class attribute
+    "D105",  # Missing docstring in magic method (__str__ etc. are self-evident)
+    "D106",  # Missing docstring in public nested class (Django/DRF Meta classes)
+    "D107",  # Missing docstring in __init__ (covered by class docstring)
+]
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",  # assert statements
+    "S106",  # hardcoded passwords
+    "PLR2004",  # Magic value comparisons in tests
+    "PLC0415",  # Import is not at top level
+    "D102",  # Test methods don't need docstrings
+    "D103",  # Test functions and fixtures don't need docstrings
+]
+
+[lint.pydocstyle]
+convention = "google"
+
+[lint.isort]
+known-first-party = [
+    "todo",
+    "umbra",
+]
+
+[lint.flake8-quotes]
+inline-quotes = "double"
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = true
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
## Summary

Moves all ruff linting and formatting configuration from `pyproject.toml` into a dedicated `ruff.toml` at the repo root, following the same separation already applied to `ty` (`ty.toml`). No rule or formatter values were changed.

## Type of change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that alters existing behavior)
- [x] Refactor (no functional change)
- [ ] Documentation update
- [ ] Dependency update

## Changes

- Created `ruff.toml` at the repo root with all ruff configuration translated to standalone-file section naming (`[tool.ruff.lint]` → `[lint]`, etc.)
- Removed all `[tool.ruff*]` sections from `pyproject.toml` — no residual references remain

## Testing

- [ ] `make test` passes (backend)
- [ ] `make test-frontend` passes (frontend)
- [ ] New tests added for new functionality
- [ ] Manually tested in the browser (for UI changes)

> No logic changed — tooling config only. `make check` verification covers this change fully.

## Pre-merge checklist

- [x] `make check` passes with zero errors (lint, format, type check)
- [x] Diagrams updated if models, views, or routes changed — N/A
- [x] ADR written in `docs/internal/decisions/` if this is a cross-layer architectural decision — ADR 0002 merged in #49
- [x] `docs/public/` changes are public-safe (if applicable) — N/A

## Related issues

Closes #47
Closes #45

## Screenshots

N/A