### PR TITLE
Upgrade Django to 6.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
-    "django>=6.0.4,<7.0.0",
+    "django>=6.0.5,<7.0.0",
     "psycopg[binary]>=3.3.4,<4.0.0",
     "django-environ>=0.13.0,<1.0.0",
     "djangorestframework>=3.17.1,<4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -119,16 +119,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.4"
+version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5b/1328f8b84fce040c404f76822bf8c57d254e368e8cbd8bd67ec2b26d75f5/django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0", size = 8368680, upload-time = "2026-05-05T13:54:33.532Z" },
 ]
 
 [[package]]
@@ -650,7 +650,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=6.0.4,<7.0.0" },
+    { name = "django", specifier = ">=6.0.5,<7.0.0" },
     { name = "django-cors-headers", specifier = ">=4.9.0,<5.0.0" },
     { name = "django-csp", specifier = ">=4.0,<5.0" },
     { name = "django-environ", specifier = ">=0.13.0,<1.0.0" },


### PR DESCRIPTION
## Summary

- Bumps the Django version constraint lower bound from `6.0.4` to `6.0.5` in `pyproject.toml`
- Regenerates `uv.lock` to resolve to Django 6.0.5
- Resolves three open Dependabot security alerts (one medium, two low)

| Alert | CVE | Severity | Description |
|---|---|---|---|
| [#37](https://github.com/masriamir/umbra/security/dependabot/37) | CVE-2026-5766 | Medium | ASGI requests with missing/understated `Content-Length` can bypass `FILE_UPLOAD_MAX_MEMORY_SIZE`, causing service degradation |
| [#38](https://github.com/masriamir/umbra/security/dependabot/38) | CVE-2026-35192 | Low | Session cookie `Vary` header omitted when `SESSION_SAVE_EVERY_REQUEST=True`, enabling session theft via cached pages |
| [#39](https://github.com/masriamir/umbra/security/dependabot/39) | CVE-2026-6907 | Low | `UpdateCacheMiddleware` incorrectly caches responses with `Vary: *`, potentially exposing private data |

## Test plan

- [x] `make check` passes (lint, format, typecheck)
- [x] `make test` passes — 107/107 tests

Closes #52