### PR TITLE
Upgrade idna to 3.18 (CVE-2026-45409)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -266,11 +266,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrades `idna` from 3.11 to 3.18 in `uv.lock` via `uv lock --upgrade-package idna`
- No changes to `pyproject.toml` — `idna` is a transitive dependency and does not need to be declared directly

**Dependency chain:** `httpx` (test group) → `idna` and `httpx` → `anyio` → `idna`

| Alert | CVE | Severity | Description |
|---|---|---|---|
| [#40](https://github.com/masriamir/umbra/security/dependabot/40) | CVE-2026-45409 | Medium | Specially crafted inputs to `idna.encode()` bypass the CVE-2024-3651 fix; high-length payloads using `valid_contexto` prior to length rejection can cause DoS. Fixed in `idna` 3.15+. |

## Test plan

- [x] `make check` passes (lint, format, typecheck)
- [x] `make test` passes — 107/107 tests

Closes #54